### PR TITLE
Removing loot, skinloot and tameable status from creatures 3939, 5766 and 14865

### DIFF
--- a/_develop/203_updatepack_mangos.sql
+++ b/_develop/203_updatepack_mangos.sql
@@ -125,6 +125,11 @@ UPDATE `creature_template` SET gossip_menu_id=685 WHERE entry=5494;
 -- Set resistances of multiple Kolkar mobs to 0
 UPDATE `creature_template` SET resistance2=0, resistance5=0 WHERE entry IN (3119,3120,3272,3273,3274,3275,3397,4632,4633,4634,4635,4636,4637,9523,9524,12976,12977);
 
+-- Remove loot (3939), skinning loots (3939,5766,14865), and make mob non tameable (3939)
+DELETE FROM `creature_loot_template` WHERE entry=3939;
+DELETE FROM `skinning_loot_template` WHERE entry=10105;
+UPDATE `creature_template` SET lootid=0, skinloot=0, type_flags=0 WHERE entry IN (3939,5766,14865);
+
 -- Cleanup
 UPDATE gameobject SET state = 0 WHERE id IN (SELECT entry FROM gameobject_template WHERE type = 0 AND data0 = 1);
 UPDATE creature_template SET unit_flags=unit_flags&~2048 WHERE unit_flags&2048=2048;


### PR DESCRIPTION
All are considered pets so shouldn't be lootable, skinable or tameable.
