### PR TITLE
Create 20003_windcaller_yessendra_reward_fix.sql

### DIFF
--- a/_updates/Rel20/20003_windcaller_yessendra_reward_fix.sql
+++ b/_updates/Rel20/20003_windcaller_yessendra_reward_fix.sql
@@ -1,0 +1,22 @@
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES
+(1718, 8, 8700, 0),
+(1719, 24, 21408, 1),
+(1720, -1, 1718, 1719),
+(1721, 8, 8699, 0),
+(1722, 24, 21414, 1),
+(1723, -1, 1721, 1722),
+(1724, 8, 8701, 0),
+(1725, 24, 21405, 1),
+(1726, -1, 1724, 1725),
+(1727, 8, 8703, 0),
+(1728, 24, 21396, 1),
+(1729, -1, 1727, 1728),
+(1730, 8, 8697, 0),
+(1731, 24, 21411, 1),
+(1732, -1, 1730, 1731);
+
+UPDATE gossip_menu_option SET condition_id=1720 WHERE menu_id = 6928 AND id = 0;
+UPDATE gossip_menu_option SET condition_id=1723 WHERE menu_id = 6928 AND id = 1;
+UPDATE gossip_menu_option SET condition_id=1726 WHERE menu_id = 6928 AND id = 2;
+UPDATE gossip_menu_option SET condition_id=1729 WHERE menu_id = 6928 AND id = 3;
+UPDATE gossip_menu_option SET condition_id=1732 WHERE menu_id = 6928 AND id = 4;


### PR DESCRIPTION
The conditions for the first five items were not correct.

This will fix all of the reward conditions for:
Band of Unending Life
Band of Vaulted Secrets
Band of Veiled Shadows
Ring of Eternal Justice
Ring of Infinite Wisdom
