### PR TITLE
Corrections made to Update database scripts

### DIFF
--- a/World/Updates/Rel20/20003_04_mangos_spell_bonus_data.sql
+++ b/World/Updates/Rel20/20003_04_mangos_spell_bonus_data.sql
@@ -1,4 +1,4 @@
-ALTER TABLE db_version CHANGE COLUMN required_20003_02_mangos_spell_bonus_data required_20003_03_mangos_spell_bonus_data bit;
+ALTER TABLE db_version CHANGE COLUMN required_20003_03_mangos_spell_bonus_data required_20003_04_mangos_spell_bonus_data bit;
 
 -- Seal of Command fix
 -- 20% SpellDamageBonusDone

--- a/World/Updates/Rel20/20003_16_Molten_Core_Creature_Cleanup.sql
+++ b/World/Updates/Rel20/20003_16_Molten_Core_Creature_Cleanup.sql
@@ -6,7 +6,7 @@
 
 */
 
-ALTER TABLE db_version CHANGE COLUMN `required_20003_03_mangos_spell_bonus_data` required_20003_16_Molten_Core_Creature_Cleanup bit;
+ALTER TABLE db_version CHANGE COLUMN `required_20003_04_mangos_spell_bonus_data` required_20003_16_Molten_Core_Creature_Cleanup bit;
 
 UPDATE `creature_template` SET `MechanicImmuneMask` = '1073594367' WHERE `creature_template`.`Entry` =11668;
 UPDATE `creature_template` SET `MechanicImmuneMask` = '1073594367' WHERE `creature_template`.`Entry` =11665;


### PR DESCRIPTION
ALTER TABLE SQL script errors (incorrect table names) fixed for:

20003_04_mangos_spell_bonus_data.sql
20003_16_Molten_Core_Creature_Cleanup.sql
