### PR TITLE
Incorrect path to full world DB corrected

### DIFF
--- a/make_full_WorldDB.sh
+++ b/make_full_WorldDB.sh
@@ -19,4 +19,4 @@ cat <<EOF > full_db.sql
 --
 EOF
 
-for i in ../_full_db/*.sql; do tail -n +18 $i >> full_db.sql; done
+for i in World/Setup/FullDB/*.sql; do tail -n +18 $i >> full_db.sql; done


### PR DESCRIPTION
The path to the world script files was incorrect (it was the old path).

Replaced with the new path, tested and working.
