### PR TITLE
Error in SQL syntax fix

### DIFF
--- a/Character/Setup/characterLoadDB.sql
+++ b/Character/Setup/characterLoadDB.sql
@@ -1264,7 +1264,7 @@ insert  into `dbdocssubtables`(`subTableId`,`languageId`,`subTableName`,`subTabl
 
 --
 -- Table structure for table `dbdocssubtables_localised`
----
+--
 DROP TABLE IF EXISTS `dbdocssubtables_localised`;
 
 CREATE TABLE `dbdocssubtables_localised` (


### PR DESCRIPTION
The 3 dashes caused the following error when attempting to apply the
script file to the characters database: ERROR 1064 at line 1267: You
have an error in your SQL syntax
