### PR TITLE
Cleansed Ripper Root looting fix

### DIFF
--- a/World/Updates/Rel20/20004_12_Corrupted_Whipper_Root.sql
+++ b/World/Updates/Rel20/20004_12_Corrupted_Whipper_Root.sql
@@ -1,0 +1,27 @@
+-- Add the Revision update into the revision column
+INSERT IGNORE INTO db_version SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 12';
+
+-- Delete Corrupted Whipper Root entries
+DELETE FROM gameobject_loot_template where item = 11951;
+
+-- REMOVE UNWANTED CLEANSED WHIPPER ROOT RECORDS (there are 2 of each, but only one of each is needed/correct - see table https://www.getmangos.eu/issue.php?issueid=653 )
+DELETE FROM gameobject WHERE `guid`='17660';
+DELETE FROM gameobject WHERE `guid`='17662';
+DELETE FROM gameobject WHERE `guid`='17664';
+DELETE FROM gameobject WHERE `guid`='18176';
+DELETE FROM gameobject WHERE `guid`='18178';
+DELETE FROM gameobject WHERE `guid`='18180';
+
+-- New gameobject_loot_template records for Cleansed Whipper Root
+-- Cleansed Whipper Root (gameobject_template: 164883, 174622, 174623, 174624, 174625, 174687)
+INSERT INTO gameobject_loot_template (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES ('164883', '11951', '10', '0', '1', '3', '0'),('174622', '11951', '10', '0', '1', '3', '0'),('174623', '11951', '10', '0', '1', '3', '0'),('174624', '11951', '10', '0', '1', '3', '0'),('174625', '11951', '10', '0', '1', '3', '0'),('174687', '11951', '10', '0', '1', '3', '0');
+
+-- Replace Cleansed Whipper Root gameobject_template records
+-- The plants will now be lootable
+DELETE FROM gameobject_template where name = "Cleansed Whipper Root";
+INSERT INTO gameobject_template (`entry`, `type`, `displayId`, `name`, `faction`, `flags`, `size`, `data0`, `data1`, `data2`, `data3`, `data4`, `data5`, `data6`, `data7`, `data8`, `data9`, `data10`, `data11`, `data12`, `data13`, `data14`, `data15`, `data16`, `data17`, `data18`, `data19`, `data20`, `data21`, `data22`, `data23`, `mingold`, `maxgold`, `ScriptName`) VALUES ('164883', '3', '3255', 'Cleansed Whipper Root', '0', '0', '2', '43', '164883', '0', '1', '1', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', ''),('174622', '3', '3255', 'Cleansed Whipper Root', '0', '0', '2', '43', '174622', '0', '1', '1', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', ''),('174623', '3', '3255', 'Cleansed Whipper Root', '0', '0', '2', '43', '174623', '0', '1', '1', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', ''),('174624', '3', '3255', 'Cleansed Whipper Root', '0', '0', '2', '43', '174624', '0', '1', '1', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', ''),('174625', '3', '3255', 'Cleansed Whipper Root', '0', '0', '2', '43', '174625', '0', '1', '1', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', ''),('174687', '3', '3255', 'Cleansed Whipper Root', '0', '0', '2', '43', '174687', '0', '1', '1', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '');
+
+-- INCORRECT GUID WAS USED FOR SPAWNING CLEANSED WHIPPER ROOT
+UPDATE dbscripts_on_quest_end SET datalong = 48882 WHERE id = 4443;
+
+

--- a/World/Updates/Rel20/20004_13_Elite_Creature_Mana_Health_fix.sql
+++ b/World/Updates/Rel20/20004_13_Elite_Creature_Mana_Health_fix.sql
@@ -1,0 +1,13 @@
+-- Add the Revision update into the revision column
+INSERT IGNORE INTO db_version SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 13';
+
+-- Author: Talendrys
+-- Tester and sub-author (corrected the mana script): tonaus 
+
+-- Correct the amount of health for the elite/boss creatures
+UPDATE creature_template, creature_template_classlevelstats SET HealthMultiplier = MinLevelHealth/BaseHealthExp0
+WHERE creature_template_classlevelstats.Level = MinLevel;
+
+-- Correct the amount of mana for the elite/boss creatures
+UPDATE creature_template, creature_template_classlevelstats SET ManaMultiplier = MinLevelMana/BaseMana
+WHERE creature_template_classlevelstats.Level = MinLevel and BaseMana != 0;

--- a/World/Updates/Rel20/20004_14_Witherbark_Axe_Throwers_Speech_fix.sql
+++ b/World/Updates/Rel20/20004_14_Witherbark_Axe_Throwers_Speech_fix.sql
@@ -5,14 +5,14 @@ INSERT IGNORE INTO db_version SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 14
 
 -- Deleted record
 -- '255402', '2554', '4', '0', '15', '0', '0', '0', '0', '0', '1', '-5', '-6', '0', '0', '0', '0', '0', '0', '0', '0', '0', 'Witherbark Axe Thrower - Random Aggro Say'
-DELETE FROM `mangosZero`.`creature_ai_scripts` WHERE `id`='255402';
+DELETE FROM creature_ai_scripts WHERE `id`='255402';
 
 -- renumber remaining records
-UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255402' WHERE `id`='255403';
-UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255403' WHERE `id`='255404';
-UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255404' WHERE `id`='255405';
-UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255405' WHERE `id`='255406';
-UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255406' WHERE `id`='255407';
-UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255407' WHERE `id`='255408';
-UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255408' WHERE `id`='255409';
-UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255409' WHERE `id`='255410';
+UPDATE creature_ai_scripts SET `id`='255402' WHERE `id`='255403';
+UPDATE creature_ai_scripts SET `id`='255403' WHERE `id`='255404';
+UPDATE creature_ai_scripts SET `id`='255404' WHERE `id`='255405';
+UPDATE creature_ai_scripts SET `id`='255405' WHERE `id`='255406';
+UPDATE creature_ai_scripts SET `id`='255406' WHERE `id`='255407';
+UPDATE creature_ai_scripts SET `id`='255407' WHERE `id`='255408';
+UPDATE creature_ai_scripts SET `id`='255408' WHERE `id`='255409';
+UPDATE creature_ai_scripts SET `id`='255409' WHERE `id`='255410';

--- a/World/Updates/Rel20/20004_14_Witherbark_Axe_Throwers_Speech_fix.sql
+++ b/World/Updates/Rel20/20004_14_Witherbark_Axe_Throwers_Speech_fix.sql
@@ -1,0 +1,18 @@
+-- Add the Revision update into the revision column
+INSERT IGNORE INTO db_version SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 14';
+
+-- No record of Witherbark Axe Throwers ever saying anything, so remove it from the database
+
+-- Deleted record
+-- '255402', '2554', '4', '0', '15', '0', '0', '0', '0', '0', '1', '-5', '-6', '0', '0', '0', '0', '0', '0', '0', '0', '0', 'Witherbark Axe Thrower - Random Aggro Say'
+DELETE FROM `mangosZero`.`creature_ai_scripts` WHERE `id`='255402';
+
+-- renumber remaining records
+UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255402' WHERE `id`='255403';
+UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255403' WHERE `id`='255404';
+UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255404' WHERE `id`='255405';
+UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255405' WHERE `id`='255406';
+UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255406' WHERE `id`='255407';
+UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255407' WHERE `id`='255408';
+UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255408' WHERE `id`='255409';
+UPDATE `mangosZero`.`creature_ai_scripts` SET `id`='255409' WHERE `id`='255410';


### PR DESCRIPTION
This fixes the looting issue with the Cleansed Whipper Root game
objects. It also removes unwanted game objects plus makes a correction
to one of the object spawned.
