### PR TITLE
Quest 8869 (Sweet Serenity) fixed

### DIFF
--- a/World/Updates/Rel20/20006_25_Quest_8869_fixed.sql
+++ b/World/Updates/Rel20/20006_25_Quest_8869_fixed.sql
@@ -1,0 +1,7 @@
+-- Add the Revision update into the revision column
+INSERT IGNORE INTO `db_version` SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 20006_25';
+
+-- Quest 8869 (Sweet Serenity fixed)
+UPDATE quest_template SET RequiredSkillValue = 250, OfferRewardText = 'May you bash in many a brain, $N!', RequestItemsText = 'His apron! Where is it?', CompleteEmote = 1 WHERE entry = 8869;
+-- Blacksmith now only has the more recent of the quests (5305 and 8869 are the same quest)
+DELETE FROM creature_involvedrelation WHERE id = 11191 and quest = 5305;

--- a/World/Updates/Rel20/20006_25_Quest_8869_fixed.sql
+++ b/World/Updates/Rel20/20006_25_Quest_8869_fixed.sql
@@ -5,3 +5,5 @@ INSERT IGNORE INTO `db_version` SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 
 UPDATE quest_template SET RequiredSkillValue = 250, OfferRewardText = 'May you bash in many a brain, $N!', RequestItemsText = 'His apron! Where is it?', CompleteEmote = 1 WHERE entry = 8869;
 -- Blacksmith now only has the more recent of the quests (5305 and 8869 are the same quest)
 DELETE FROM creature_involvedrelation WHERE id = 11191 and quest = 5305;
+DELETE FROM creature_questrelation WHERE id = 11191 and quest = 5305;
+


### PR DESCRIPTION
Quest 8869 (Sweet Serenity) now works

Blacksmith now only has the more recent of the quests (5305 and 8869 are
the same quest)
