### PR TITLE
[Quest][811] Badlands Reagent Run II requires Alchemy 210

### DIFF
--- a/World/Updates/Rel20/20006_26_Quest_2203_requirements.sql
+++ b/World/Updates/Rel20/20006_26_Quest_2203_requirements.sql
@@ -1,0 +1,5 @@
+-- Add the Revision update into the revision column
+INSERT IGNORE INTO `db_version` SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 20006_26';
+
+-- Quest 2203 (Badlands Reagent Run II) set required Alchemy skill value as for quest 2501
+UPDATE quest_template SET RequiredSkillValue = 210 WHERE entry = 2203;

--- a/World/Updates/Rel20/20006_26_Quest_2203_requirements.sql
+++ b/World/Updates/Rel20/20006_26_Quest_2203_requirements.sql
@@ -1,0 +1,5 @@
+-- Add the Revision update into the revision column
+INSERT IGNORE INTO `db_version` SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 20006_26';
+
+-- Quest 2203 (Badlands Reagent Run II)
+UPDATE quest_template SET RequiredSkillValue = 1 WHERE entry = 2203;

--- a/World/Updates/Rel20/20006_26_Quest_2203_requirements.sql
+++ b/World/Updates/Rel20/20006_26_Quest_2203_requirements.sql
@@ -1,5 +1,0 @@
--- Add the Revision update into the revision column
-INSERT IGNORE INTO `db_version` SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 20006_26';
-
--- Quest 2203 (Badlands Reagent Run II)
-UPDATE quest_template SET RequiredSkillValue = 1 WHERE entry = 2203;


### PR DESCRIPTION
Requirement was 0, thus the presence of Alchemy skill was not required at all.
