### PR TITLE
Dont stop HP regen for all the casters

### DIFF
--- a/World/Updates/Rel20/20007_02_Corrections_To_RegenerateStats_And_Mana.sql
+++ b/World/Updates/Rel20/20007_02_Corrections_To_RegenerateStats_And_Mana.sql
@@ -2,6 +2,6 @@
 INSERT IGNORE INTO `db_version` SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 20007_02';
 
 UPDATE creature_template SET RegenerateStats=1 WHERE UnitClass IN (1, 4) AND RegenerateStats != 0;
-UPDATE creature_template SET RegenerateStats=2 WHERE UnitClass IN (2, 8) AND RegenerateStats != 0;
+UPDATE creature_template SET RegenerateStats=RegenerateStats|2 WHERE UnitClass IN (2, 8);
 
 UPDATE creature_template SET MinLevelMana = 0, MaxLevelMana = 0, ManaMultiplier = 0 where UnitClass = 1 or UnitClass = 4 and MinLevelMana > 0;


### PR DESCRIPTION
RegenerateStats field is a bitmask, see enum RegenStatsFlags in Creature.h and use of these constants. So normal value for all casters should be 3 (= 2|1), and a special value only MP but not HP regen (though never encountered) should be 2 (= 2|0).
