### PR TITLE
[815] Life Tap should not scale with SP

### DIFF
--- a/World/Updates/Rel20/20007_10_Life_Tap_Scaling.sql
+++ b/World/Updates/Rel20/20007_10_Life_Tap_Scaling.sql
@@ -1,0 +1,6 @@
+-- [815] Life Tap is not scaled with spell damage/healing (PARTIAL FIX)
+-- however the numbers are strange, probably due to spell levels
+INSERT IGNORE INTO `db_version` SET `Version` = 'MaNGOSZero Database 2.0.11 Rev 20007_10';
+
+DELETE FROM `spell_bonus_data` WHERE `entry`=1454;
+INSERT INTO `spell_bonus_data` (`entry`,`ap_bonus`,`comments`) VALUES (1454,1,'Life Tap - no scaling with SP');


### PR DESCRIPTION
Better, but the numbers from spells are strange still. The lower ranks are influenced much stronger; for the highest rank, effect of T8 bonus (-12% health cost) is absent at all. It is probably due to some wrong calculations with character/spell levels.
